### PR TITLE
期間指定ボタンを作成

### DIFF
--- a/app/javascript/packs/graphs.js
+++ b/app/javascript/packs/graphs.js
@@ -1,7 +1,15 @@
 document.addEventListener('turbolinks:load', () => {
-    // '2020-01-12'のような文字列から，Javascriptの日付オブジェクトを取得する関数
+        // '2020-01-12'のような文字列から，Javascriptの日付オブジェクトを取得する関数
     // setHoursを使用しないと，時差の影響で0時にならないため注意！
     const convertDate = (date) => new Date(new Date(date).setHours(0, 0, 0, 0))
+    
+    // 日付の古い方・新しい方を取得する関数
+    const minDate = (date1, date2) => (date1 < date2) ? date1 : date2
+    const maxDate = (date1, date2) => (date1 > date2) ? date1 : date2
+
+    // データの初日・最終日
+    const START_DATE = convertDate(gon.weight_records[0].date)
+    const END_DATE = convertDate(gon.weight_records[gon.weight_records.length - 1].date)
 
     const TODAY = convertDate(new Date())
     const A_WEEK_AGO = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() - 6)
@@ -11,7 +19,10 @@ document.addEventListener('turbolinks:load', () => {
 
     // グラフを描く場所を取得
     const chartWeightContext = document.getElementById("chart-weight").getContext('2d')
+
+    // グラフ（ drawGraph 関数の外で変数宣言をしなければならない!）
     let chartWeight
+
     // 期間を指定してグラフを描く
     const drawGraph = (from, to) => {
         // from から to までの期間のデータに絞る
@@ -75,7 +86,34 @@ document.addEventListener('turbolinks:load', () => {
             chartWeight.update()
         }
     }
+    // 引数の日付から今日までのグラフを描く関数
+        const drawGraphToToday = (from) => {
+            // データが存在する範囲に修正
+            from = maxDate(from, START_DATE)
+            let to = minDate(TODAY, END_DATE)
+            drawGraph(from, to)
+            // フォームの開始日・終了日を変更する
+            startCalendarFlatpickr.setDate(from)
+            endCalendarFlatpickr.setDate(to)
+        }
+
+        // 過去◯週間のグラフを描くボタン
+        document.getElementById('a-week-button').addEventListener('click', () => {
+            drawGraphToToday(A_WEEK_AGO)
+        })
+
+        document.getElementById('two-weeks-button').addEventListener('click', () => {
+            drawGraphToToday(TWO_WEEKS_AGO)
+        })
+
+        document.getElementById('a-month-button').addEventListener('click', () => {
+            drawGraphToToday(A_MONTH_AGO)
+        })
+
+        document.getElementById('three-months-button').addEventListener('click', () => {
+            drawGraphToToday(THREE_MONTHS_AGO)
+        })
 
     // グラフの初期表示
-    drawGraph(A_WEEK_AGO, TODAY)
+    drawGraphToToday(A_WEEK_AGO)
 })

--- a/app/javascript/packs/graphs.js
+++ b/app/javascript/packs/graphs.js
@@ -11,7 +11,7 @@ document.addEventListener('turbolinks:load', () => {
 
     // グラフを描く場所を取得
     const chartWeightContext = document.getElementById("chart-weight").getContext('2d')
-
+    let chartWeight
     // 期間を指定してグラフを描く
     const drawGraph = (from, to) => {
         // from から to までの期間のデータに絞る
@@ -56,11 +56,24 @@ document.addEventListener('turbolinks:load', () => {
             }
         }
 
-        new Chart(chartWeightContext, {
-            type: 'line',
-            data: weightData,
-            options: weightOption
-        })
+        // new Chart(chartWeightContext, {
+        //     type: 'line',
+        //     data: weightData,
+        //     options: weightOption
+        // })
+        if (!chartWeight) {
+            // グラフが存在しないときは，作成する
+            chartWeight = new Chart(chartWeightContext, {
+                type: 'line',
+                data: weightData,
+                options: weightOption
+            })
+        } else {
+            // グラフが存在するときは，更新する
+            chartWeight.data = weightData
+            chartWeight.options = weightOption
+            chartWeight.update()
+        }
     }
 
     // グラフの初期表示

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,2 +1,16 @@
 <%= Gon::Base.render_data %>
-<canvas id="chart-weight"></canvas>
+<div class="row">
+  <div class="col-6 col-sm-3">
+    <input type="button" value="過去１週間" id="a-week-button" class="btn btn-success btn-block mt-3">
+  </div>
+  <div class="col-6 col-sm-3">
+    <input type="button" value="過去２週間" id="two-weeks-button" class="btn btn-success btn-block mt-3">
+  </div>
+  <div class="col-6 col-sm-3">
+    <input type="button" value="過去１ヶ月" id="a-month-button" class="btn btn-success btn-block mt-3">
+  </div>
+  <div class="col-6 col-sm-3">
+    <input type="button" value="過去３ヶ月" id="three-months-button" class="btn btn-success btn-block mt-3">
+  </div>
+</div>
+<canvas id="chart-weight" class="mt-5"></canvas>


### PR DESCRIPTION
colse #8 
#実装内容

- drawGraph関数の修正
- 過去◯週間ボタンを作成
   -  ボタンを横並びさせるため，Bootstrapのグリッドシステムを利用
   - レスポンシブ対応（横幅が短いときはボタンを 2×2 で表示）