### PR TITLE
期間指定ボタンを作成

### DIFF
--- a/app/javascript/packs/graphs.js
+++ b/app/javascript/packs/graphs.js
@@ -11,6 +11,33 @@ document.addEventListener('turbolinks:load', () => {
     const START_DATE = convertDate(gon.weight_records[0].date)
     const END_DATE = convertDate(gon.weight_records[gon.weight_records.length - 1].date)
 
+    // カレンダーの日本語化
+    flatpickr.localize(flatpickr.l10ns.ja)
+    const drawGraphForPeriod = () => {
+        let from = convertDate(document.getElementById('start-calendar').value)
+        let to = convertDate(document.getElementById('end-calendar').value)
+
+        if (from > to) {
+            alert('終了日は開始日以降の日付に設定して下さい')
+        } else {
+            drawGraph(from, to)
+        }
+    }
+    
+    const periodCalendarOption = {
+        // スマートフォンでもカレンダーに「flatpickr」を使用
+        disableMobile: true,
+        // 選択できる期間を設定
+        minDate: START_DATE,
+        maxDate: END_DATE,
+        // 日付選択後のイベント
+        onChange: drawGraphForPeriod
+    }
+
+    // カレンダー
+    const startCalendarFlatpickr = flatpickr('#start-calendar', periodCalendarOption)
+    const endCalendarFlatpickr = flatpickr('#end-calendar', periodCalendarOption)
+
     const TODAY = convertDate(new Date())
     const A_WEEK_AGO = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() - 6)
     const TWO_WEEKS_AGO = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() - 13)

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,4 +1,18 @@
 <%= Gon::Base.render_data %>
+<div class="row no-gutters">
+  <div class="input-group col-sm-6 pr-sm-3 mt-3">
+    <div class="input-group-prepend">
+      <span class="input-group-text">開始</span>
+    </div>
+    <input type="text" id="start-calendar" class="form-control bg-white text-center">
+  </div>
+  <div class="input-group col-sm-6 pl-sm-3 mt-3">
+    <div class="input-group-prepend">
+      <span class="input-group-text">終了</span>
+    </div>
+    <input type="text" id="end-calendar" class="form-control bg-white text-center">
+  </div>
+</div>
 <div class="row">
   <div class="col-6 col-sm-3">
     <input type="button" value="過去１週間" id="a-week-button" class="btn btn-success btn-block mt-3">


### PR DESCRIPTION
close #9 
# 実装内容

- 開始日・終了日のカレンダーを作成
- カレンダーにflatpickrを適用
- 開始日・終了日を変更したとき，グラフが更新されるように設定
※過去◯週間のボタンを押した時に，日付が自動入力の設定は済